### PR TITLE
Feature/add service balancer gateway

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f565e5caa1b349ec404c6d03d01c68b02233f5485ed038d0aab810dd4023a880",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.34.0"
+  hashes = [
+    "h1:Aetzu1M/Un/PYGjluPslF2VTXTb3vFrejCcU/nyaRis=",
+    "zh:076b451dc8629c49f4260de6d43595e98ac5f1bdbebb01d112659ef94d99451f",
+    "zh:0c29855dbd3c6ba82fce680fa5ac969d4e09e20fecb4ed40166b778bd19895a4",
+    "zh:583b4dfcea4d8392dd7904c00b2ff41bbae78d238e8b72e5ad580370a24a4ecb",
+    "zh:5e20844d8d1af052381d00de4febd4055ad0f3c3c02795c361265b9ef72a1075",
+    "zh:766b7ab7c4727c62b5887c3922e0467c4cc355ba0dc3aabe465ebb86bc1caabb",
+    "zh:776a5000b441d7c8262d17d4a4aa4aa9760ae64de4cb7172961d9e007e0be1e5",
+    "zh:7838f509235116e55adeeecbe6def3da1b66dd3c4ce0de02fc7dc66a60e1d630",
+    "zh:931e5581ec66c145c1d29198bd23fddc8d0c5cbf4cda22e02dba65644c7842f2",
+    "zh:95e728efa2a31a63b879fd093507466e509e3bfc9325eb35ea3dc28fed15c6f7",
+    "zh:972b9e3ca2b6a1057dcf5003fc78cabb0dd8847580bddeb52d885ebd64df38ea",
+    "zh:ef6114217965d55f5bddbd7a316b8f85f15b8a77c075fcbed95813039d522e0a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/build.sh
+++ b/terraform/build.sh
@@ -15,7 +15,6 @@ develop | staging | production)
     terraform output -raw ecr_repository_uri_shipping >./options-"$1"/ecr_repository_uri_shipping.txt
     terraform output -raw ecr_repository_uri_payments >./options-"$1"/ecr_repository_uri_payments.txt
     terraform output -raw ecr_repository_uri_products >./options-"$1"/ecr_repository_uri_products.txt
-    terraform output -raw website_url >./options-"$1"/s3_website_url.txt
     terraform output -raw bucket_name >./options-"$1"/s3_bucket_name.txt
     ;;
 *)

--- a/terraform/build.sh
+++ b/terraform/build.sh
@@ -11,7 +11,10 @@ develop | staging | production)
     # Aplica plan
     terraform apply -var-file="$1.tfvars" #-auto-approve #quizás es mejor validar y luego escribir yes.
     # Guarda referencias a recursos resultantes en el directorio "options" correspondiente.
-    terraform output -raw ecr_repository_uri >./options-"$1"/ecr_repository_uri.txt
+    terraform output -raw ecr_repository_uri_orders >./options-"$1"/ecr_repository_uri_orders.txt
+    terraform output -raw ecr_repository_uri_shipping >./options-"$1"/ecr_repository_uri_shipping.txt
+    terraform output -raw ecr_repository_uri_payments >./options-"$1"/ecr_repository_uri_payments.txt
+    terraform output -raw ecr_repository_uri_products >./options-"$1"/ecr_repository_uri_products.txt
     terraform output -raw website_url >./options-"$1"/s3_website_url.txt
     terraform output -raw bucket_name >./options-"$1"/s3_bucket_name.txt
     ;;

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -15,3 +15,14 @@ variable "role_arn" {
   description = "ARN del rol IAM."
   type        = string
 }
+variable "instance_types" {
+  description = "Lista de tipos de instancia EC2 para el node group"
+  type        = list(string)
+  default     = ["t2.micro"]
+}
+
+variable "capacity_type" {
+  description = "Tipo de capacidad para las instancias EC2. Valores: ON_DEMAND, SPOT"
+  type        = string
+  default     = "SPOT"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -140,9 +140,8 @@ resource "aws_security_group" "security_group_public_obligatario" {
 
 }
 
-resource "aws_ecr_repository" "ecr_obligatorio" {
-  for_each = toset(["orders", "shipping", "payments","products"])
-  name     = "ecr_obligatorio_${each.key}"
+resource "aws_ecr_repository" "ecr_obligatorio_orders" {
+  name = "ecr_obligatorio_orders"
 
   image_scanning_configuration {
     scan_on_push = true
@@ -151,8 +150,49 @@ resource "aws_ecr_repository" "ecr_obligatorio" {
   image_tag_mutability = "MUTABLE"
 
   tags = {
-    Environment = each.key
-    Project     = "Obligatorio"
+    Project = "Obligatorio"
+  }
+}
+
+resource "aws_ecr_repository" "ecr_obligatorio_shipping" {
+  name = "ecr_obligatorio_shipping"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  image_tag_mutability = "MUTABLE"
+
+  tags = {
+    Project = "Obligatorio"
+  }
+}
+
+resource "aws_ecr_repository" "ecr_obligatorio_payments" {
+  name = "ecr_obligatorio_payments"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  image_tag_mutability = "MUTABLE"
+
+  tags = {
+    Project = "Obligatorio"
+  }
+}
+
+resource "aws_ecr_repository" "ecr_obligatorio_products" {
+  name = "ecr_obligatorio_products"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  image_tag_mutability = "MUTABLE"
+
+  tags = {
+    Project = "Obligatorio"
   }
 }
 
@@ -188,9 +228,8 @@ resource "aws_eks_node_group" "node_group_obligatorio" {
     max_size     = "5"
   }
 
-  instance_types = ["t2.micro"] #TODO: Hacer variable
-  capacity_type  = "SPOT"
-
+  instance_types = var.instance_types
+  capacity_type  = var.capacity_type
   tags = {
     Environment = var.environment
   }
@@ -224,7 +263,7 @@ resource "aws_apigatewayv2_route" "http_route" {
 
 resource "aws_apigatewayv2_stage" "http_stage" {
   api_id      = aws_apigatewayv2_api.http_api_obligatorio.id
-  name        = "develop" #Crear Variable
+  name        = "develop" #TODO:Crear Variable o crear todos los stages asociados a cada entorno
   description = "Develop" #Actualizar de acuerdo al entorno
   auto_deploy = true
 }

--- a/terraform/options-develop/ecr_repository_uri.txt
+++ b/terraform/options-develop/ecr_repository_uri.txt
@@ -1,1 +1,0 @@
-140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_develop

--- a/terraform/options-develop/ecr_repository_uri_orders.txt
+++ b/terraform/options-develop/ecr_repository_uri_orders.txt
@@ -1,0 +1,1 @@
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_orders

--- a/terraform/options-develop/ecr_repository_uri_orders.txt
+++ b/terraform/options-develop/ecr_repository_uri_orders.txt
@@ -1,1 +1,1 @@
-140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_orders
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_orders

--- a/terraform/options-develop/ecr_repository_uri_payments.txt
+++ b/terraform/options-develop/ecr_repository_uri_payments.txt
@@ -1,1 +1,1 @@
-140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_payments
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_payments

--- a/terraform/options-develop/ecr_repository_uri_payments.txt
+++ b/terraform/options-develop/ecr_repository_uri_payments.txt
@@ -1,0 +1,1 @@
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_payments

--- a/terraform/options-develop/ecr_repository_uri_products.txt
+++ b/terraform/options-develop/ecr_repository_uri_products.txt
@@ -1,0 +1,1 @@
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_products

--- a/terraform/options-develop/ecr_repository_uri_products.txt
+++ b/terraform/options-develop/ecr_repository_uri_products.txt
@@ -1,1 +1,1 @@
-140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_products
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_products

--- a/terraform/options-develop/ecr_repository_uri_shipping.txt
+++ b/terraform/options-develop/ecr_repository_uri_shipping.txt
@@ -1,0 +1,1 @@
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_shipping

--- a/terraform/options-develop/ecr_repository_uri_shipping.txt
+++ b/terraform/options-develop/ecr_repository_uri_shipping.txt
@@ -1,1 +1,1 @@
-140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_obligatorio_shipping
+140598534703.dkr.ecr.us-east-1.amazonaws.com/ecr_shipping

--- a/terraform/options-develop/s3_bucket_name.txt
+++ b/terraform/options-develop/s3_bucket_name.txt
@@ -1,1 +1,1 @@
-develop-obligatorio-3m-f5e1faa5-0daa-1ac9-ba13-39e433883a6e
+develop-obligatorio-3m-74f1304c-c556-9955-527c-6e6c30171d2d

--- a/terraform/options-develop/s3_bucket_name.txt
+++ b/terraform/options-develop/s3_bucket_name.txt
@@ -1,1 +1,1 @@
-develop-obligatorio-3m-6dea8c1d-97b2-8b77-44f9-b1bd6e876b8f
+develop-obligatorio-3m-f5e1faa5-0daa-1ac9-ba13-39e433883a6e

--- a/terraform/options-develop/s3_bucket_name.txt
+++ b/terraform/options-develop/s3_bucket_name.txt
@@ -1,1 +1,1 @@
-develop-obligatorio-3m-447507ed-3d20-1ab4-13f7-708b0dd7e7a1
+develop-obligatorio-3m-6dea8c1d-97b2-8b77-44f9-b1bd6e876b8f

--- a/terraform/options-develop/s3_bucket_name.txt
+++ b/terraform/options-develop/s3_bucket_name.txt
@@ -1,1 +1,1 @@
-develop-obligatorio-3m-74f1304c-c556-9955-527c-6e6c30171d2d
+develop-obligatorio-3m-2f7290eb-f87e-8fc1-2d9b-c6876f3c95d4

--- a/terraform/options-develop/s3_website_url.txt
+++ b/terraform/options-develop/s3_website_url.txt
@@ -1,1 +1,0 @@
-develop-obligatorio-3m-6dea8c1d-97b2-8b77-44f9-b1bd6e876b8f.s3-website-us-east-1.amazonaws.com

--- a/terraform/options-develop/s3_website_url.txt
+++ b/terraform/options-develop/s3_website_url.txt
@@ -1,1 +1,1 @@
-develop-obligatorio-3m-447507ed-3d20-1ab4-13f7-708b0dd7e7a1.s3-website-us-east-1.amazonaws.com
+develop-obligatorio-3m-6dea8c1d-97b2-8b77-44f9-b1bd6e876b8f.s3-website-us-east-1.amazonaws.com

--- a/terraform/options-staging/s3_bucket_name.txt
+++ b/terraform/options-staging/s3_bucket_name.txt
@@ -1,0 +1,1 @@
+staging-obligatorio-3m-9ef19958-45c7-9371-4681-babc0a032935

--- a/terraform/options-staging/s3_website_url.txt
+++ b/terraform/options-staging/s3_website_url.txt
@@ -1,0 +1,1 @@
+staging-obligatorio-3m-9ef19958-45c7-9371-4681-babc0a032935.s3-website-us-east-1.amazonaws.com

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,12 +5,6 @@
 #Generando un archivo json:
 #   terraform output -json > outputs.json
 
-output "ecr_repository_uri" {
-  value       = aws_ecr_repository.ecr_obligatorio.repository_url
-  description = "La URI del repositorio ECR creado"
-  depends_on = [ aws_ecr_repository.ecr_obligatorio ]
-}
-
 output "ecr_repository_uri_orders" {
   value       = aws_ecr_repository.ecr_obligatorio_orders.repository_url
   description = "La URI del repositorio de orders"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,3 +10,27 @@ output "ecr_repository_uri" {
   description = "La URI del repositorio ECR creado"
   depends_on = [ aws_ecr_repository.ecr_obligatorio ]
 }
+
+output "ecr_repository_uri_orders" {
+  value       = aws_ecr_repository.ecr_obligatorio_orders.repository_url
+  description = "La URI del repositorio de orders"
+  depends_on = [ aws_ecr_repository.ecr_obligatorio_orders ]
+}
+
+output "ecr_repository_uri_shipping" {
+  value       = aws_ecr_repository.ecr_obligatorio_shipping.repository_url
+  description = "La URI del repositorio de shipping"
+  depends_on = [ aws_ecr_repository.ecr_obligatorio_shipping ]
+}
+
+output "ecr_repository_uri_payments" {
+  value       = aws_ecr_repository.ecr_obligatorio_payments.repository_url
+  description = "La URI del repositorio de payments"
+  depends_on = [ aws_ecr_repository.ecr_obligatorio_payments ]
+}
+
+output "ecr_repository_uri_products" {
+  value       = aws_ecr_repository.ecr_obligatorio_products.repository_url
+  description = "La URI del repositorio de products"
+  depends_on = [ aws_ecr_repository.ecr_obligatorio_products ]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,23 +8,32 @@
 output "ecr_repository_uri_orders" {
   value       = aws_ecr_repository.ecr_obligatorio_orders.repository_url
   description = "La URI del repositorio de orders"
-  depends_on = [ aws_ecr_repository.ecr_obligatorio_orders ]
+  depends_on  = [aws_ecr_repository.ecr_obligatorio_orders]
 }
 
 output "ecr_repository_uri_shipping" {
   value       = aws_ecr_repository.ecr_obligatorio_shipping.repository_url
   description = "La URI del repositorio de shipping"
-  depends_on = [ aws_ecr_repository.ecr_obligatorio_shipping ]
+  depends_on  = [aws_ecr_repository.ecr_obligatorio_shipping]
 }
 
 output "ecr_repository_uri_payments" {
   value       = aws_ecr_repository.ecr_obligatorio_payments.repository_url
   description = "La URI del repositorio de payments"
-  depends_on = [ aws_ecr_repository.ecr_obligatorio_payments ]
+  depends_on  = [aws_ecr_repository.ecr_obligatorio_payments]
 }
 
 output "ecr_repository_uri_products" {
   value       = aws_ecr_repository.ecr_obligatorio_products.repository_url
   description = "La URI del repositorio de products"
-  depends_on = [ aws_ecr_repository.ecr_obligatorio_products ]
+  depends_on  = [aws_ecr_repository.ecr_obligatorio_products]
+}
+
+output "http_api_obligatorio_url" {
+  value       = aws_apigatewayv2_api.http_api_obligatorio.api_endpoint
+  description = "Base URL of the HTTP API Gateway"
+}
+
+output "bucket_name" {
+  value = module.static_site.bucket_name
 }


### PR DESCRIPTION
Mayores:
- Se crea un nodegroup con 2 pods mínimo y máximo 5
- Se separan los ECR en 4 (orders, shipping, payments,products)
	- se modifica el terraform para generar los 4 ECR 
	- se crean 4 nuevos archivos de configuración con la URL de cada ECR por separado. Para ser consumidos por los CD de los repos.
Menores:
- Se crean variables para el tipo de instancia (t2.micro) y tipo de capacidad (spot)
- Se eliminar el archivo de salida con la url del s3 bucket. Porque en el deploy del front solamente se usa el nombre del bucket.
- Se eliminan declaraciones de elementos que ya no son necesarios porque no se crean objetos del cluster desde terraform
